### PR TITLE
Add HTTP interface

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -1,0 +1,8 @@
+defmodule Mater.HTTP do
+  @moduledoc """
+  HTTP Client interface to communicate with GraphQL APIs.
+  """
+
+  def call(),
+    do: :todo
+end

--- a/lib/http/interface.ex
+++ b/lib/http/interface.ex
@@ -1,0 +1,14 @@
+defmodule Mater.HTTP.Interface do
+  @moduledoc """
+  This module represents the interface functions that
+  should be implemented when using HTTP Clients to
+  access a GraphQL API resource.
+  """
+
+  @type endpoint :: String.t()
+  @type body :: %{query: String.t(), variables: String.t()}
+  @type opts :: Keyword.t()
+  @type response :: {:ok, map()} | {:error, map()}
+
+  @callback call(endpoint, body, opts) :: response
+end

--- a/lib/http/poison.ex
+++ b/lib/http/poison.ex
@@ -1,0 +1,31 @@
+defmodule Mater.HTTP.Poison do
+  @moduledoc false
+
+  @behaviour Mater.HTTP.Interface
+
+  @impl true
+  def call(endpoint, body, opts) do
+    case HTTPoison.post(endpoint, Jason.encode!(body), decode_opts(opts)) do
+      {:ok, %HTTPoison.Response{body: body, status_code: 200}} ->
+        {:ok, Jason.decode!(body)}
+
+      {:ok, %HTTPoison.Response{body: body}} ->
+        {:error, Jason.decode!(body)}
+
+      {:error, %HTTPoison.Error{reason: :nxdomain}} ->
+        {:error, :invalid_endpoint}
+
+      error ->
+        error
+    end
+  end
+
+  defp decode_opts(opts),
+    do: decode_opts(opts, [])
+
+  defp decode_opts([{:auth, auth} | rest], acc),
+    do: decode_opts(rest, [{"Authorization", auth} | acc])
+
+  defp decode_opts([], acc),
+    do: acc
+end

--- a/lib/mater.ex
+++ b/lib/mater.ex
@@ -15,7 +15,7 @@ defmodule Mater do
   ## Examples
 
       iex> Mater.call("", %{})
-      {:error, :no_scheme}
+      {:error, :invalid_endpoint}
   """
   @spec call(
           endpoint :: String.t(),
@@ -26,27 +26,8 @@ defmodule Mater do
   def call(endpoint, body, opts \\ [])
 
   def call("", _, _),
-    do: {:error, :no_scheme}
+    do: {:error, :invalid_endpoint}
 
-  def call(endpoint, body, opts) do
-    case HTTPoison.post(endpoint, Jason.encode!(body), decode_opts(opts)) do
-      {:ok, %HTTPoison.Response{body: body, status_code: 200}} ->
-        {:ok, Jason.decode!(body)}
-
-      {:ok, %HTTPoison.Response{body: body}} ->
-        {:error, Jason.decode!(body)}
-
-      error ->
-        error
-    end
-  end
-
-  defp decode_opts(opts),
-    do: decode_opts(opts, [])
-
-  defp decode_opts([{:auth, auth} | rest], acc),
-    do: decode_opts(rest, [{"Authorization", auth} | acc])
-
-  defp decode_opts([], acc),
-    do: acc
+  def call(endpoint, body, opts),
+    do: Mater.HTTP.Poison.call(endpoint, body, opts)
 end

--- a/test/mater_test.exs
+++ b/test/mater_test.exs
@@ -34,11 +34,11 @@ defmodule MaterTest do
 
   describe "Mater Errors" do
     test "returns error when invalid graphql endpoint" do
-      assert {:error, %HTTPoison.Error{reason: :nxdomain}} = Mater.call("invalid_endpoint", %{})
+      assert {:error, :invalid_endpoint} = Mater.call("invalid_endpoint", %{})
     end
 
     test "returns error when empty string endpoint" do
-      assert {:error, :no_scheme} = Mater.call("", %{})
+      assert {:error, :invalid_endpoint} = Mater.call("", %{})
     end
   end
 end


### PR DESCRIPTION
Add a new HTTP Interface to abstract which Client implementation will be used while querying data from a GraphQL Endpoint